### PR TITLE
Replace hard-coded  link with a clickable link

### DIFF
--- a/getting_started_julia/getting_started.ipynb
+++ b/getting_started_julia/getting_started.ipynb
@@ -329,7 +329,7 @@
     "\n",
     "While you can individually download the notebooks from the website, the easiest way to access the notebooks is usually to clone the repository with Git into your JupyterHub environment.\n",
     "\n",
-    "JupyterHub installations have different methods for cloning repositories, with which you can use the url for the notebooks repository: `https://github.com/QuantEcon/quantecon-notebooks-julia`.\n",
+    "JupyterHub installations have different methods for cloning repositories, with which you can use the url for the notebooks repository: https://github.com/QuantEcon/quantecon-notebooks-julia.\n",
     "\n",
     "\n",
     "<a id='package-setup'></a>"


### PR DESCRIPTION
It's way harder to select and copy a link inside `code syntax`, compared to the https://url.syntax, for which the same actions are done in two clicks.