### PR TITLE
Update getting_started.ipynb

### DIFF
--- a/getting_started_julia/getting_started.ipynb
+++ b/getting_started_julia/getting_started.ipynb
@@ -374,7 +374,7 @@
    "source": [
     "```julia\n",
     "using InstantiateFromURL\n",
-    "github_project(\"QuantEcon/quantecon-notebooks-julia\", version = \"0.8.0\", instantiate = true, precompile = true)\n",
+    "github_project(\"QuantEcon/quantecon-notebooks-julia\", version = \"0.8.0\", force = true)\n",
     "```\n"
    ]
   },


### PR DESCRIPTION
Did not work 🙅 

```sh
julia> github_project("QuantEcon/quantecon-notebooks-julia", version = "0.8.0", instantiate = true, precompile = true)
ERROR: MethodError: no method matching github_project(::String; version="0.8.0", instantiate=true, precompile=true)
Closest candidates are:
  github_project(::Any; path, version, force) at /Users/kirillseva/.julia/packages/InstantiateFromURL/stReR/src/github_project.jl:31 got unsupported keyword arguments "instantiate", "precompile"
Stacktrace:
 [1] kwerr(::NamedTuple{(:version, :instantiate, :precompile),Tuple{String,Bool,Bool}}, ::Function, ::String) at ./error.jl:157
 [2] top-level scope at none:0
```

Worked ✅ 
```julia
julia>  github_project("QuantEcon/quantecon-notebooks-julia", version = "0.8.0", force = true)
```